### PR TITLE
version, control field, size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,6 @@ AC_CONFIG_FILES([
 	libtinyframe.pc
     src/Makefile
     src/test/Makefile
-    src/tinyframe/tinyframe.h
+    src/tinyframe/version.h
 ])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,6 +6,7 @@ SUBDIRS = test
 lib_LTLIBRARIES = libtinyframe.la
 
 libtinyframe_la_SOURCES = tinyframe.c
-nobase_nodist_include_HEADERS = tinyframe/tinyframe.h
+nobase_include_HEADERS = tinyframe/tinyframe.h
+nobase_nodist_include_HEADERS = tinyframe/version.h
 libtinyframe_la_LDFLAGS = -version-info $(TINYFRAME_LIBRARY_VERSION)
-EXTRA_DIST += tinyframe/tinyframe.h.in
+EXTRA_DIST += tinyframe/version.h.in

--- a/src/tinyframe.c
+++ b/src/tinyframe.c
@@ -157,6 +157,9 @@ enum tinyframe_result tinyframe_read(struct tinyframe_reader* handle, const uint
 
 enum tinyframe_result tinyframe_write_control_start(struct tinyframe_writer* handle, uint8_t* out, size_t len, const char* content_type, size_t content_type_len)
 {
+    if (content_type_len > TINYFRAME_CONTROL_FIELD_CONTENT_TYPE_LENGTH_MAX) {
+        return tinyframe_error;
+    }
     if (len < 12 + 8 + content_type_len) {
         return tinyframe_need_more;
     }
@@ -173,7 +176,7 @@ enum tinyframe_result tinyframe_write_control_start(struct tinyframe_writer* han
     return tinyframe_ok;
 }
 
-enum tinyframe_result tinyframe_write_frame(struct tinyframe_writer* handle, uint8_t* out, size_t len, const uint8_t* data, size_t data_len)
+enum tinyframe_result tinyframe_write_frame(struct tinyframe_writer* handle, uint8_t* out, size_t len, const uint8_t* data, uint32_t data_len)
 {
     if (len < 4 + data_len) {
         return tinyframe_need_more;
@@ -201,7 +204,7 @@ enum tinyframe_result tinyframe_write_control_stop(struct tinyframe_writer* hand
     return tinyframe_ok;
 }
 
-void tinyframe_set_header(uint8_t* frame, size_t frame_length)
+void tinyframe_set_header(uint8_t* frame, uint32_t frame_length)
 {
     _put32(frame, frame_length);
 }

--- a/src/tinyframe/tinyframe.h
+++ b/src/tinyframe/tinyframe.h
@@ -19,17 +19,13 @@
  * along with tinyframe library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <tinyframe/version.h>
+
 #include <unistd.h>
 #include <stdint.h>
 
 #ifndef __tinyframe_h_tinyframe
 #define __tinyframe_h_tinyframe 1
-
-#define TINYFRAME_VERSION @TINYFRAME_VERSION_MAJOR@@TINYFRAME_VERSION_MINOR@@TINYFRAME_VERSION_PATCH@
-#define TINYFRAME_VERSION_MAJOR @TINYFRAME_VERSION_MAJOR@
-#define TINYFRAME_VERSION_MINOR @TINYFRAME_VERSION_MINOR@
-#define TINYFRAME_VERSION_PATCH @TINYFRAME_VERSION_PATCH@
-#define TINYFRAME_VERSION_STRING "@PACKAGE_VERSION@"
 
 #define TINYFRAME_CONTROL_FRAME_LENGTH_MAX 512
 #define TINYFRAME_CONTROL_FIELD_CONTENT_TYPE_LENGTH_MAX 256
@@ -130,9 +126,9 @@ enum tinyframe_result {
 enum tinyframe_result tinyframe_read(struct tinyframe_reader*, const uint8_t*, size_t);
 
 enum tinyframe_result tinyframe_write_control_start(struct tinyframe_writer*, uint8_t*, size_t, const char*, size_t);
-enum tinyframe_result tinyframe_write_frame(struct tinyframe_writer*, uint8_t*, size_t, const uint8_t*, size_t);
+enum tinyframe_result tinyframe_write_frame(struct tinyframe_writer*, uint8_t*, size_t, const uint8_t*, uint32_t);
 enum tinyframe_result tinyframe_write_control_stop(struct tinyframe_writer*, uint8_t*, size_t);
 
-void tinyframe_set_header(uint8_t*, size_t);
+void tinyframe_set_header(uint8_t*, uint32_t);
 
 #endif

--- a/src/tinyframe/version.h.in
+++ b/src/tinyframe/version.h.in
@@ -1,0 +1,31 @@
+/*
+ * Author Jerry Lundström <jerry@dns-oarc.net>
+ * Copyright (c) 2019, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of the tinyframe library.
+ *
+ * tinyframe library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * tinyframe library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with tinyframe library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __tinyframe_h_version
+#define __tinyframe_h_version 1
+
+#define TINYFRAME_VERSION @TINYFRAME_VERSION_MAJOR@@TINYFRAME_VERSION_MINOR@@TINYFRAME_VERSION_PATCH@
+#define TINYFRAME_VERSION_MAJOR @TINYFRAME_VERSION_MAJOR@
+#define TINYFRAME_VERSION_MINOR @TINYFRAME_VERSION_MINOR@
+#define TINYFRAME_VERSION_PATCH @TINYFRAME_VERSION_PATCH@
+#define TINYFRAME_VERSION_STRING "@PACKAGE_VERSION@"
+
+#endif


### PR DESCRIPTION
- Move version to generated `dnswire/version.h`
- Add check for control field content type length
- Use `uint32_t` instead of `size_t` for data and frame length