### PR TITLE
trace, write control, control length left, frame size

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,10 @@ AC_ARG_WITH([extra-ldflags], [AS_HELP_STRING([--with-extra-ldflags=CFLAGS], [Add
   AS_VAR_APPEND(LDFLAGS, [" $withval"])
 ])
 
+# Check --enable-trace
+AH_TEMPLATE([TINYFRAME_TRACE], [Defined if trace of Frame Streams is enabled])
+AC_ARG_ENABLE([trace], [AS_HELP_STRING([--enable-trace], [Enable trace output of Frame Streams])], [AC_DEFINE([TINYFRAME_TRACE])])
+
 # pkg-config
 PKG_INSTALLDIR
 

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -10,4 +10,5 @@ EXTRA_DIST = $(TESTS)
 
 test1_SOURCES = test1.c
 test1_LDADD = ../libtinyframe.la
+test1_LDFLAGS = -static
 EXTRA_DIST += test.fstrm

--- a/src/tinyframe.c
+++ b/src/tinyframe.c
@@ -36,6 +36,42 @@
 #endif
 #endif
 #include <assert.h>
+#ifdef TINYFRAME_TRACE
+#include <stdio.h>
+#include <ctype.h>
+static const char* printable_string(const uint8_t* data, size_t len)
+{
+    static char buf[512];
+    size_t      r = 0, w = 0;
+
+    while (r < len && w < sizeof(buf) - 1) {
+        if (isprint(data[r])) {
+            buf[w++] = data[r++];
+        } else {
+            if (w + 4 >= sizeof(buf) - 1) {
+                break;
+            }
+
+            sprintf(&buf[w], "\\x%02x", data[r++]);
+            w += 4;
+        }
+    }
+    if (w >= sizeof(buf)) {
+        buf[sizeof(buf) - 1] = 0;
+    } else {
+        buf[w] = 0;
+    }
+
+    return buf;
+}
+#define trace(x...)                                \
+    fprintf(stderr, "tinyframe %s(): ", __func__); \
+    fprintf(stderr, x);                            \
+    fprintf(stderr, "\n")
+#else
+#define trace(x...)
+#define printable_string(x...)
+#endif
 
 static inline uint32_t _need32(const void* ptr)
 {
@@ -53,14 +89,17 @@ static inline void _put32(void* ptr, uint32_t v)
 static inline enum tinyframe_result __read_control(struct tinyframe_reader* handle, const uint8_t* data, size_t len)
 {
     if (len < 12) {
+        trace("data len %zu < 12, need more", len);
         return tinyframe_need_more;
     }
     handle->control.length = _need32(data); // "escape"
     if (handle->control.length) {
+        trace("control length zero, error");
         return tinyframe_error;
     }
     handle->control.length = _need32(data + 4); // length
     if (handle->control.length > TINYFRAME_CONTROL_FRAME_LENGTH_MAX) {
+        trace("control length > max, error");
         return tinyframe_error;
     }
     handle->control.type = _need32(data + 8); // type
@@ -75,16 +114,20 @@ static inline enum tinyframe_result __read_control(struct tinyframe_reader* hand
     case TINYFRAME_CONTROL_FINISH:
         return tinyframe_finished;
     default:
+        trace("control type %d invalid, error", handle->control.type);
         return tinyframe_error;
     }
 
     // "escape" and length are not included in length, if not just type
     // then we have control fields
     if (handle->control.length > 4) {
-        handle->state          = tinyframe_control_field;
-        handle->control_length = handle->control.length - 4; // - type length
+        handle->state               = tinyframe_control_field;
+        handle->control_length      = handle->control.length - 4; // - type length
+        handle->control_length_left = handle->control_length;
+        trace("control %d len %zu, next fields", handle->control.type, handle->control_length);
     } else {
         handle->state = tinyframe_frame;
+        trace("control %d len %zu, next frame", handle->control.type, handle->control_length);
     }
 
     handle->bytes_read = 12;
@@ -102,6 +145,7 @@ enum tinyframe_result tinyframe_read(struct tinyframe_reader* handle, const uint
 
     case tinyframe_control_field:
         if (len < 8) {
+            trace("data len %zu < 8 for control field, need more", len);
             return tinyframe_need_more;
         }
         handle->control_field.type = _need32(data);
@@ -109,32 +153,39 @@ enum tinyframe_result tinyframe_read(struct tinyframe_reader* handle, const uint
         case TINYFRAME_CONTROL_FIELD_CONTENT_TYPE:
             break;
         default:
+            trace("control field type %d invalid, error", handle->control_field.type);
             return tinyframe_error;
         }
 
         handle->control_field.length = _need32(data + 4);
         if (handle->control_field.length > TINYFRAME_CONTROL_FIELD_CONTENT_TYPE_LENGTH_MAX) {
+            trace("control field length > max, error");
             return tinyframe_error;
         }
         if (len - 8 < handle->control_field.length) {
+            trace("data len %zu < control field length, need more", len - 8);
             return tinyframe_need_more;
         }
 
         // did we over read control frame length?
-        if (handle->control_length < handle->control_field.length + 8) {
+        if (handle->control_length_left < handle->control_field.length + 8) {
+            trace("control field goes beyond control, error");
             return tinyframe_error;
         }
-        handle->control_length -= handle->control_field.length + 8;
-        if (!handle->control_length) {
+        handle->control_length_left -= handle->control_field.length + 8;
+        if (!handle->control_length_left) {
+            trace("no control fields left, next frame");
             handle->state = tinyframe_frame;
         }
 
         handle->control_field.data = data + 8;
         handle->bytes_read         = 8 + handle->control_field.length;
+        trace("control field %d, data: %s", handle->control_field.type, printable_string(handle->control_field.data, handle->control_field.length));
         return tinyframe_have_control_field;
 
     case tinyframe_frame:
         if (len < 4) {
+            trace("data len %zu < 4 for frame, need more", len);
             return tinyframe_need_more;
         }
         handle->frame.length = _need32(data);
@@ -144,23 +195,66 @@ enum tinyframe_result tinyframe_read(struct tinyframe_reader* handle, const uint
         }
 
         if (len - 4 < handle->frame.length) {
+            trace("data len %zu < frame length, need more", len - 4);
             return tinyframe_need_more;
         }
 
         handle->frame.data = data + 4;
         handle->bytes_read = 4 + handle->frame.length;
+        trace("frame data: %s...", printable_string(data, handle->bytes_read > 20 ? 20 : handle->bytes_read));
         return tinyframe_have_frame;
     }
 
     return tinyframe_error;
 }
 
+enum tinyframe_result tinyframe_write_control(struct tinyframe_writer* handle, uint8_t* out, size_t len, uint32_t type, const struct tinyframe_control_field* fields, size_t num_fields)
+{
+    size_t   out_len = 12;
+    size_t   n;
+    uint8_t* outp;
+
+    for (n = 0; n < num_fields; n++) {
+        if (fields[n].length > TINYFRAME_CONTROL_FIELD_CONTENT_TYPE_LENGTH_MAX) {
+            trace("field %zu length > max, error", n);
+            return tinyframe_error;
+        }
+        out_len += 8 + fields[n].length;
+    }
+
+    if (len < out_len) {
+        trace("not enought space, need more");
+        return tinyframe_need_more;
+    }
+
+    _put32(out, 0); // "escape"
+    _put32(out + 4, out_len - 8); // length
+    // - 8 is because "escape" and length is not included in length
+    _put32(out + 8, type); // type
+
+    outp = out + 12;
+    for (n = 0; n < num_fields; n++) {
+        _put32(outp, fields[n].type);
+        _put32(outp + 4, fields[n].length);
+        if (fields[n].length) {
+            memcpy(outp + 8, fields[n].data, fields[n].length);
+        }
+        outp += 8 + fields[n].length;
+    }
+
+    handle->bytes_wrote = out_len;
+    trace("control %u data: %s", type, printable_string(out, handle->bytes_wrote));
+    return tinyframe_ok;
+}
+
 enum tinyframe_result tinyframe_write_control_start(struct tinyframe_writer* handle, uint8_t* out, size_t len, const char* content_type, size_t content_type_len)
 {
     if (content_type_len > TINYFRAME_CONTROL_FIELD_CONTENT_TYPE_LENGTH_MAX) {
+        trace("field length > max, error");
         return tinyframe_error;
     }
     if (len < 12 + 8 + content_type_len) {
+        trace("not enought space, need more");
         return tinyframe_need_more;
     }
 
@@ -173,12 +267,14 @@ enum tinyframe_result tinyframe_write_control_start(struct tinyframe_writer* han
     memcpy(out + 20, content_type, content_type_len); // field data
 
     handle->bytes_wrote = 12 + 8 + content_type_len;
+    trace("control start data: %s", printable_string(out, handle->bytes_wrote));
     return tinyframe_ok;
 }
 
 enum tinyframe_result tinyframe_write_frame(struct tinyframe_writer* handle, uint8_t* out, size_t len, const uint8_t* data, uint32_t data_len)
 {
     if (len < 4 + data_len) {
+        trace("not enought space, need more");
         return tinyframe_need_more;
     }
 
@@ -186,12 +282,14 @@ enum tinyframe_result tinyframe_write_frame(struct tinyframe_writer* handle, uin
     memcpy(out + 4, data, data_len); // frame
 
     handle->bytes_wrote = 4 + data_len;
+    trace("frame data: %s...", printable_string(out, handle->bytes_wrote > 20 ? 20 : handle->bytes_wrote));
     return tinyframe_ok;
 }
 
 enum tinyframe_result tinyframe_write_control_stop(struct tinyframe_writer* handle, uint8_t* out, size_t len)
 {
     if (len < 12) {
+        trace("not enought space, need more");
         return tinyframe_need_more;
     }
 
@@ -201,6 +299,7 @@ enum tinyframe_result tinyframe_write_control_stop(struct tinyframe_writer* hand
     _put32(out + 8, TINYFRAME_CONTROL_STOP); // type
 
     handle->bytes_wrote = 12;
+    trace("control stop data: %s", printable_string(out, handle->bytes_wrote));
     return tinyframe_ok;
 }
 

--- a/src/tinyframe/tinyframe.h
+++ b/src/tinyframe/tinyframe.h
@@ -50,15 +50,15 @@ struct tinyframe_control {
     }
 
 struct tinyframe_control_field {
-    uint32_t       length;
     uint32_t       type;
+    uint32_t       length;
     const uint8_t* data;
 };
 
 #define TINYFRAME_CONTROL_FIELD_INITIALIZER \
     {                                       \
-        .length = 0,                        \
         .type   = 0,                        \
+        .length = 0,                        \
         .data   = 0,                        \
     }
 
@@ -84,7 +84,7 @@ enum tinyframe_state {
 struct tinyframe_reader {
     enum tinyframe_state state;
 
-    size_t control_length;
+    size_t control_length, control_length_left;
 
     struct tinyframe_control       control;
     struct tinyframe_control_field control_field;
@@ -93,14 +93,15 @@ struct tinyframe_reader {
     size_t bytes_read;
 };
 
-#define TINYFRAME_READER_INITIALIZER                           \
-    {                                                          \
-        .state          = tinyframe_control,                   \
-        .control_length = 0,                                   \
-        .control        = TINYFRAME_CONTROL_INITIALIZER,       \
-        .control_field  = TINYFRAME_CONTROL_FIELD_INITIALIZER, \
-        .frame          = TINYFRAME_INITIALIZER,               \
-        .bytes_read     = 0,                                   \
+#define TINYFRAME_READER_INITIALIZER                                \
+    {                                                               \
+        .state               = tinyframe_control,                   \
+        .control_length      = 0,                                   \
+        .control_length_left = 0,                                   \
+        .control             = TINYFRAME_CONTROL_INITIALIZER,       \
+        .control_field       = TINYFRAME_CONTROL_FIELD_INITIALIZER, \
+        .frame               = TINYFRAME_INITIALIZER,               \
+        .bytes_read          = 0,                                   \
     }
 
 struct tinyframe_writer {
@@ -125,10 +126,17 @@ enum tinyframe_result {
 
 enum tinyframe_result tinyframe_read(struct tinyframe_reader*, const uint8_t*, size_t);
 
+enum tinyframe_result tinyframe_write_control(struct tinyframe_writer*, uint8_t*, size_t, uint32_t, const struct tinyframe_control_field*, size_t);
+
 enum tinyframe_result tinyframe_write_control_start(struct tinyframe_writer*, uint8_t*, size_t, const char*, size_t);
 enum tinyframe_result tinyframe_write_frame(struct tinyframe_writer*, uint8_t*, size_t, const uint8_t*, uint32_t);
 enum tinyframe_result tinyframe_write_control_stop(struct tinyframe_writer*, uint8_t*, size_t);
 
 void tinyframe_set_header(uint8_t*, uint32_t);
+
+static inline size_t tinyframe_frame_size(size_t data_len)
+{
+    return 4 + data_len;
+}
 
 #endif


### PR DESCRIPTION
- Add compile time option for tracing operations
- Fix tests
- Add `tinyframe_write_control()` to write any control frame with zero or more control fields
- Add `control_length_left` to `tinyframe_reader` to keep track of how much more is left of the control frame instead of using `control_length`
- Add `tinyframe_frame_size()` to calculate the frame size