### PR TITLE
Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ m4/ltversion.m4
 m4/lt~obsolete.m4
 build/
 config.h.in
+
+libtinyframe.pc
+src/tinyframe/version.h

--- a/sonar-project.properties.local
+++ b/sonar-project.properties.local
@@ -1,0 +1,1 @@
+sonar.coverage.exclusions=src/test/**

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -4,8 +4,8 @@ CLEANFILES = test*.log test*.trs test2.fstrm *.gcda *.gcno *.gcov
 
 AM_CFLAGS = -I$(top_srcdir)/src
 
-check_PROGRAMS = test1 test2
-TESTS = test1.sh test2.sh
+check_PROGRAMS = test1 test2 test3
+TESTS = test1.sh test2.sh test3.sh
 EXTRA_DIST = $(TESTS)
 
 test1_SOURCES = test1.c
@@ -17,9 +17,13 @@ test2_SOURCES = test2.c
 test2_LDADD = ../libtinyframe.la
 test2_LDFLAGS = -static
 
+test3_SOURCES = test3.c
+test3_LDADD = ../libtinyframe.la
+test3_LDFLAGS = -static
+
 if ENABLE_GCOV
 gcov-local:
-	for src in $(test1_SOURCES) $(test2_SOURCES); do \
+	for src in $(test1_SOURCES) $(test2_SOURCES) $(test3_SOURCES); do \
 	  gcov -l -r -s "$(srcdir)" "$$src"; \
 	done
 endif

--- a/src/test/test1.c
+++ b/src/test/test1.c
@@ -1,3 +1,24 @@
+/*
+ * Author Jerry Lundström <jerry@dns-oarc.net>
+ * Copyright (c) 2020, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of the tinyframe library.
+ *
+ * tinyframe library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * tinyframe library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with tinyframe library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <tinyframe/tinyframe.h>
 
 #include <stdio.h>

--- a/src/test/test2.c
+++ b/src/test/test2.c
@@ -1,3 +1,24 @@
+/*
+ * Author Jerry Lundström <jerry@dns-oarc.net>
+ * Copyright (c) 2020, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of the tinyframe library.
+ *
+ * tinyframe library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * tinyframe library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with tinyframe library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 #include <tinyframe/tinyframe.h>
 
 #include <stdio.h>

--- a/src/test/test3.c
+++ b/src/test/test3.c
@@ -1,0 +1,93 @@
+/*
+ * Author Jerry Lundström <jerry@dns-oarc.net>
+ * Copyright (c) 2020, OARC, Inc.
+ * All rights reserved.
+ *
+ * This file is part of the tinyframe library.
+ *
+ * tinyframe library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * tinyframe library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with tinyframe library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include <tinyframe/tinyframe.h>
+
+#include <assert.h>
+#include <string.h>
+#ifdef HAVE_ENDIAN_H
+#include <endian.h>
+#else
+#ifdef HAVE_SYS_ENDIAN_H
+#include <sys/endian.h>
+#else
+#ifdef HAVE_MACHINE_ENDIAN_H
+#include <machine/endian.h>
+#endif
+#endif
+#endif
+
+static inline uint32_t _need32(const void* ptr)
+{
+    uint32_t v;
+    memcpy(&v, ptr, sizeof(v));
+    return be32toh(v);
+}
+
+int main(void)
+{
+    assert(tinyframe_frame_size(0) == 4);
+
+    struct tinyframe_writer writer = TINYFRAME_WRITER_INITIALIZER;
+    static struct tinyframe_control_field _content_type = {
+        TINYFRAME_CONTROL_FIELD_CONTENT_TYPE,
+        4,
+        (uint8_t*)"test",
+    };
+    uint8_t out[64];
+
+    // correct control
+    assert(tinyframe_write_control(&writer, out, sizeof(out), TINYFRAME_CONTROL_READY, 0, 0) == tinyframe_ok);
+    assert(tinyframe_write_control(&writer, out, sizeof(out), TINYFRAME_CONTROL_READY, &_content_type, 1) == tinyframe_ok);
+
+    // wrong control field type
+    _content_type.type = 0;
+    assert(tinyframe_write_control(&writer, out, sizeof(out), TINYFRAME_CONTROL_READY, &_content_type, 1) == tinyframe_error);
+    _content_type.type = TINYFRAME_CONTROL_FIELD_CONTENT_TYPE;
+
+    // too large control field
+    _content_type.length = TINYFRAME_CONTROL_FIELD_CONTENT_TYPE_LENGTH_MAX + 1;
+    assert(tinyframe_write_control(&writer, out, sizeof(out), TINYFRAME_CONTROL_READY, &_content_type, 1) == tinyframe_error);
+    _content_type.length = 4;
+
+    // too small buffer
+    assert(tinyframe_write_control(&writer, out, 1, TINYFRAME_CONTROL_READY, &_content_type, 1) == tinyframe_need_more);
+
+    // too large control field
+    assert(tinyframe_write_control_start(&writer, out, sizeof(out), "test", TINYFRAME_CONTROL_FIELD_CONTENT_TYPE_LENGTH_MAX + 1) == tinyframe_error);
+
+    // too small buffer
+    assert(tinyframe_write_control_start(&writer, out, 1, "test", 4) == tinyframe_need_more);
+
+    // too small buffer
+    assert(tinyframe_write_frame(&writer, out, 1, out, 4) == tinyframe_need_more);
+
+    // too small buffer
+    assert(tinyframe_write_control_stop(&writer, out, 1) == tinyframe_need_more);
+
+    // correct
+    tinyframe_set_header(out, 111);
+    assert(_need32(out) == 111);
+
+    return 0;
+}

--- a/src/test/test3.sh
+++ b/src/test/test3.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -xe
+
+./test3

--- a/src/tinyframe.c
+++ b/src/tinyframe.c
@@ -252,7 +252,18 @@ enum tinyframe_result tinyframe_write_control(struct tinyframe_writer* handle, u
     size_t   n;
     uint8_t* outp;
 
+    assert(handle);
+    assert(out);
+    assert(!num_fields || (num_fields && fields));
+
     for (n = 0; n < num_fields; n++) {
+        switch (fields[n].type) {
+        case TINYFRAME_CONTROL_FIELD_CONTENT_TYPE:
+            break;
+        default:
+            trace("field %zu type %d invalid, error", n, fields[n].type);
+            return tinyframe_error;
+        }
         if (fields[n].length > TINYFRAME_CONTROL_FIELD_CONTENT_TYPE_LENGTH_MAX) {
             trace("field %zu length > max, error", n);
             return tinyframe_error;
@@ -275,6 +286,7 @@ enum tinyframe_result tinyframe_write_control(struct tinyframe_writer* handle, u
         _put32(outp, fields[n].type);
         _put32(outp + 4, fields[n].length);
         if (fields[n].length) {
+            assert(fields[n].data);
             memcpy(outp + 8, fields[n].data, fields[n].length);
         }
         outp += 8 + fields[n].length;
@@ -287,6 +299,10 @@ enum tinyframe_result tinyframe_write_control(struct tinyframe_writer* handle, u
 
 enum tinyframe_result tinyframe_write_control_start(struct tinyframe_writer* handle, uint8_t* out, size_t len, const char* content_type, size_t content_type_len)
 {
+    assert(handle);
+    assert(out);
+    assert(content_type);
+
     if (content_type_len > TINYFRAME_CONTROL_FIELD_CONTENT_TYPE_LENGTH_MAX) {
         trace("field length > max, error");
         return tinyframe_error;
@@ -311,6 +327,10 @@ enum tinyframe_result tinyframe_write_control_start(struct tinyframe_writer* han
 
 enum tinyframe_result tinyframe_write_frame(struct tinyframe_writer* handle, uint8_t* out, size_t len, const uint8_t* data, uint32_t data_len)
 {
+    assert(handle);
+    assert(out);
+    assert(data);
+
     if (len < 4 + data_len) {
         trace("not enought space, need more");
         return tinyframe_need_more;
@@ -326,6 +346,9 @@ enum tinyframe_result tinyframe_write_frame(struct tinyframe_writer* handle, uin
 
 enum tinyframe_result tinyframe_write_control_stop(struct tinyframe_writer* handle, uint8_t* out, size_t len)
 {
+    assert(handle);
+    assert(out);
+
     if (len < 12) {
         trace("not enought space, need more");
         return tinyframe_need_more;
@@ -343,6 +366,8 @@ enum tinyframe_result tinyframe_write_control_stop(struct tinyframe_writer* hand
 
 void tinyframe_set_header(uint8_t* frame, uint32_t frame_length)
 {
+    assert(frame);
+
     _put32(frame, frame_length);
 }
 


### PR DESCRIPTION
- Exclude more generated files
- `sonar`: Exclude test code from coverage
- Add test for more coverage
- `tinyframe_write_control()`:
  - assert arguments and content fields data
  - check for valid content field types
- `tinyframe_write_control_start()`: assert arguments
- `tinyframe_write_frame()`: assert arguments
- `tinyframe_write_control_stop()`: assert arguments
- `tinyframe_set_header()`: assert arguments